### PR TITLE
Support older Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: python
 
 matrix:
-  allow_failures:
-    # the operator is not 2.7-compatiable
-    - python: 2.7
-    # the operator is not 3.5-compatiable
-    - python: 3.5
-
   include:
     # airflow supports Python 2.7 and 3.5
     - python: 2.7
@@ -19,10 +13,17 @@ matrix:
       script:
         - tests/test.sh
 
+    - python: 3.6
+      install:
+        - pip install -r requirements-lint.txt
+        - pip install -r requirements-dev.txt
+      script:
+        - tests/lint.sh
+        - tests/test.sh
+
     # Needed for Python >= 3.7
     # https://docs.travis-ci.com/user/languages/python/#python-37-and-higher
     - dist: xenial
-      # black doesn't run on old Python versions
       python: 3.7
       install:
         - pip install -r requirements-lint.txt

--- a/bedrock_plugin.py
+++ b/bedrock_plugin.py
@@ -81,7 +81,7 @@ class CreatePipelineOperator(BaseOperator):
         username,
         password,
         config_file_path="bedrock.hcl",
-        **kwargs,
+        **kwargs
     ):
         super().__init__(**kwargs)
         self.conn_id = conn_id
@@ -162,7 +162,9 @@ class RunPipelineOperator(BaseOperator):
         data = json.loads(res.content)
         pipeline_run_id = data["entity_id"]
         self.pipeline_run_id = pipeline_run_id  # Used for cleanup only
-        self.log.info("Pipeline successfully run, pipeline run ID: {}".format(pipeline_run_id))
+        self.log.info(
+            "Pipeline successfully run, pipeline run ID: {}".format(pipeline_run_id)
+        )
 
         # Poll pipeline run status
         while True:

--- a/bedrock_plugin.py
+++ b/bedrock_plugin.py
@@ -18,7 +18,7 @@ class BedrockHook(HttpHook):
     def __init__(self, method, bedrock_conn_id):
         super().__init__(method=method, http_conn_id=bedrock_conn_id)
         self.conn = self.get_connection(bedrock_conn_id)
-        self.base_url = f"https://{self.conn.host}"
+        self.base_url = "https://{}".format(self.conn.host)
 
         self.bedrock_token = None
         self.bedrock_token_expiry = None
@@ -31,7 +31,7 @@ class BedrockHook(HttpHook):
         session = requests.Session()
         session.headers.update(
             {
-                "Authorization": f"Bearer {self.bedrock_token}",
+                "Authorization": "Bearer {}".format(self.bedrock_token),
                 "Content-Type": "application/json",
             }
         )
@@ -52,9 +52,9 @@ class BedrockHook(HttpHook):
             # TODO: Remove basic auth support once we fully support oauth
             conn = HTTPSConnection(self.conn.host)
             auth_token = b64encode(
-                f"{self.conn.login}:{self.conn.password}".encode()
+                "{}:{}".format(self.conn.login, self.conn.password).encode()
             ).decode("ascii")
-            headers = {"Authorization": f"Basic {auth_token}"}
+            headers = {"Authorization": "Basic {}".format(auth_token)}
             conn.request("GET", "/v1/auth/login", headers=headers)
 
         resp = conn.getresponse()
@@ -70,7 +70,7 @@ class BedrockHook(HttpHook):
 
 
 class CreatePipelineOperator(BaseOperator):
-    CREATE_PIPELINE_PATH = f"{API_VERSION}/pipeline/"
+    CREATE_PIPELINE_PATH = "{}/pipeline/".format(API_VERSION)
 
     def __init__(
         self,
@@ -113,15 +113,15 @@ class CreatePipelineOperator(BaseOperator):
 
         data = json.loads(res.content)
         public_id = data["public_id"]
-        self.log.info(f"Pipeline successfully created, public ID: {public_id}")
+        self.log.info("Pipeline successfully created, public ID: {}".format(public_id))
         return public_id
 
 
 class RunPipelineOperator(BaseOperator):
-    GET_ENVIRONMENT_PATH = f"{API_VERSION}/environment/"
-    RUN_PIPELINE_PATH = f"{API_VERSION}/pipeline/{{}}/run/"
-    GET_PIPELINE_RUN_PATH = f"{API_VERSION}/run/{{}}"
-    STOP_PIPELINE_RUN_PATH = f"{API_VERSION}/training_run/{{}}/status"
+    GET_ENVIRONMENT_PATH = "{}/environment/".format(API_VERSION)
+    RUN_PIPELINE_PATH = "{}/pipeline/{{}}/run/".format(API_VERSION)
+    GET_PIPELINE_RUN_PATH = "{}/run/{{}}".format(API_VERSION)
+    STOP_PIPELINE_RUN_PATH = "{}/training_run/{{}}/status".format(API_VERSION)
     WAIT_STATUS = ["Running", "Queued"]
     SUCCESS_STATUS = ["Succeeded"]
 
@@ -162,7 +162,7 @@ class RunPipelineOperator(BaseOperator):
         data = json.loads(res.content)
         pipeline_run_id = data["entity_id"]
         self.pipeline_run_id = pipeline_run_id  # Used for cleanup only
-        self.log.info(f"Pipeline successfully run, pipeline run ID: {pipeline_run_id}")
+        self.log.info("Pipeline successfully run, pipeline run ID: {}".format(pipeline_run_id))
 
         # Poll pipeline run status
         while True:
@@ -173,10 +173,10 @@ class RunPipelineOperator(BaseOperator):
                 break
             else:
                 self._cleanup_run(pipeline_run_id)
-                raise Exception(f"Run status is {status}")
+                raise Exception("Run status is {}".format(status))
 
     def _check_status(self, hook, pipeline_run_id):
-        self.log.info(f"Checking status")
+        self.log.info("Checking status")
 
         try:
             res = hook.run(
@@ -190,16 +190,16 @@ class RunPipelineOperator(BaseOperator):
         data = json.loads(res.content)
 
         status = data["status"]
-        self.log.info(f"Status of pipeline run: {status}")
+        self.log.info("Status of pipeline run: {}".format(status))
         return status
 
     def _cleanup_run(self, pipeline_run_id):
-        self.log.info(f"Stopping pipeline run")
+        self.log.info("Stopping pipeline run")
         try:
             hook = BedrockHook(method="POST", bedrock_conn_id=self.conn_id)
             hook.run(RunPipelineOperator.STOP_PIPELINE_RUN_PATH.format(pipeline_run_id))
         except AirflowException as ex:
-            self.log.info(f"Failed to stop pipeline run status: {ex}")
+            self.log.info("Failed to stop pipeline run status: {}".format(ex))
             # Don't raise if we failed to stop
 
     def on_kill(self):

--- a/bedrock_plugin.py
+++ b/bedrock_plugin.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import time
 from base64 import b64encode
+from builtins import super
 from http.client import HTTPSConnection
 
 import requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 # Python 2.7 does not have pytest 5
-future==0.17.1
 pytest==4.6.4
 apache-airflow==1.10.3
 # recursive dependencies of airflow
 flask==1.0.4
+future<0.17,>=0.16.0
 jinja2==2.10.0
 werkzeug==0.14.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 # Python 2.7 does not have pytest 5
+future==0.17.1
 pytest==4.6.4
 apache-airflow==1.10.3
 # recursive dependencies of airflow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from airflow.hooks.http_hook import HttpHook
 from airflow.models import Connection
 
 
-def get_connection_mock(conn_id: str):
+def get_connection_mock(conn_id):
     conn = Connection(
         conn_id=conn_id,
         conn_type="HTTP",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
-from unittest.mock import patch
-
+import sys
 import pytest
 from airflow.hooks.http_hook import HttpHook
 from airflow.models import Connection
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 
 def get_connection_mock(conn_id):

--- a/tests/test_bedrock_hook.py
+++ b/tests/test_bedrock_hook.py
@@ -17,8 +17,8 @@ def test_authenticate(airflow_connection):
     access_token = "some_access_token"
     expires_in = 60
     now = datetime.datetime(2001, 1, 1, 0, 0, 0)
-    authenticate_return_value = (
-        f'{{"access_token":"{access_token}","expires_in":"{expires_in}"}}'
+    authenticate_return_value = '{{"access_token":"{}","expires_in":"{}"}}'.format(
+        access_token, expires_in
     )
 
     h = BedrockHook(method="POST", bedrock_conn_id=airflow_connection)

--- a/tests/test_bedrock_hook.py
+++ b/tests/test_bedrock_hook.py
@@ -56,7 +56,7 @@ def test_get_conn_calls_authenticate_with_no_token(airflow_connection):
     h._authenticate = auth_mock
 
     h.get_conn(None)
-    auth_mock.assert_called_once()
+    auth_mock.assert_called_once_with()
 
 
 def test_get_conn_calls_authenticate_with_expired_token(airflow_connection):
@@ -67,4 +67,4 @@ def test_get_conn_calls_authenticate_with_expired_token(airflow_connection):
     h._authenticate = auth_mock
 
     h.get_conn(None)
-    auth_mock.assert_called_once()
+    auth_mock.assert_called_once_with()

--- a/tests/test_bedrock_hook.py
+++ b/tests/test_bedrock_hook.py
@@ -1,8 +1,12 @@
 import datetime
+import sys
 from http.client import HTTPResponse
-from unittest.mock import Mock, patch
-
 from bedrock_plugin import BedrockHook
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import Mock, patch
+else:
+    from mock import Mock, patch
 
 
 def test_init(airflow_connection):

--- a/tests/test_bedrock_hook.py
+++ b/tests/test_bedrock_hook.py
@@ -44,8 +44,8 @@ def test_get_conn_headers(airflow_connection):
 
     headers = h.get_conn(None).headers
 
-    assert headers["Authorization"] == f"Bearer {bedrock_token}"
-    assert headers["Content-Type"] == f"application/json"
+    assert headers["Authorization"] == "Bearer {}".format(bedrock_token)
+    assert headers["Content-Type"] == "application/json"
 
 
 def test_get_conn_calls_authenticate_with_no_token(airflow_connection):

--- a/tests/test_create_pipeline_operator.py
+++ b/tests/test_create_pipeline_operator.py
@@ -1,10 +1,13 @@
 import datetime
 import json
-from unittest.mock import PropertyMock, call, patch
-
+import sys
 from airflow import DAG
-
 from bedrock_plugin import BedrockHook, CreatePipelineOperator
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import PropertyMock, call, patch
+else:
+    from mock import PropertyMock, call, patch
 
 
 def test_create_pipeline(airflow_connection):

--- a/tests/test_run_pipeline_operator.py
+++ b/tests/test_run_pipeline_operator.py
@@ -119,15 +119,15 @@ def test_run_pipeline_failure(airflow_connection):
     def bedrockhook_run_side_effect(endpoint, *_args, **_kwargs):
         resp = PropertyMock()
         if endpoint == RunPipelineOperator.RUN_PIPELINE_PATH.format(pipeline_id):
-            resp.content = f'{{"entity_id": "{run_id}"}}'
+            resp.content = '{{"entity_id": "{}"}}'.format(run_id)
         elif endpoint == RunPipelineOperator.GET_PIPELINE_RUN_PATH.format(run_id):
-            resp.content = f'{{"status": "{fail_status}"}}'
+            resp.content = '{{"status": "{}"}}'.format(fail_status)
         elif endpoint == RunPipelineOperator.GET_ENVIRONMENT_PATH:
-            resp.content = f'[{{"public_id": "{environment_id}"}}]'
+            resp.content = '[{{"public_id": "{}"}}]'.format(environment_id)
         elif endpoint == RunPipelineOperator.STOP_PIPELINE_RUN_PATH.format(run_id):
-            resp.content = f"OK"
+            resp.content = "OK"
         else:
-            pytest.fail(f"Called with bad args: {endpoint}")
+            pytest.fail("Called with bad args: {}".format(endpoint))
         return resp
 
     with patch.object(
@@ -135,7 +135,7 @@ def test_run_pipeline_failure(airflow_connection):
     ) as mock_resp, pytest.raises(Exception) as ex:
         op.execute(None)
 
-    assert ex.value.args[0] == f"Run status is {fail_status}"
+    assert ex.value.args[0] == "Run status is {}".format(fail_status)
     assert mock_resp.call_count >= 4
 
     get_env_call, run_pipeline_call, check_status_call, stop_run_call, *others = (

--- a/tests/test_run_pipeline_operator.py
+++ b/tests/test_run_pipeline_operator.py
@@ -24,11 +24,13 @@ def test_run_pipeline(airflow_connection):
     def bedrockhook_run_side_effect(endpoint, *_args, **_kwargs):
         resp = PropertyMock()
         if endpoint == RunPipelineOperator.RUN_PIPELINE_PATH.format(pipeline_id):
-            resp.content = f'{{"entity_id": "{run_id}"}}'
+            resp.content = '{{"entity_id": "{}"}}'.format(run_id)
         elif endpoint == RunPipelineOperator.GET_PIPELINE_RUN_PATH.format(run_id):
-            resp.content = f'{{"status": "{RunPipelineOperator.SUCCESS_STATUS[0]}"}}'
+            resp.content = '{{"status": "{}"}}'.format(
+                RunPipelineOperator.SUCCESS_STATUS[0]
+            )
         elif endpoint == RunPipelineOperator.GET_ENVIRONMENT_PATH:
-            resp.content = f'[{{"public_id": "{environment_id}"}}]'
+            resp.content = '[{{"public_id": "{}"}}]'.format(environment_id)
         else:
             pytest.fail("Called with bad args")
         return resp
@@ -68,19 +70,21 @@ def test_run_pipeline_waiting(airflow_connection):
     def bedrockhook_run_side_effect(endpoint, *_args, **_kwargs):
         resp = PropertyMock()
         if endpoint == RunPipelineOperator.RUN_PIPELINE_PATH.format(pipeline_id):
-            resp.content = f'{{"entity_id": "{run_id}"}}'
+            resp.content = '{{"entity_id": "{}"}}'.format(run_id)
         elif endpoint == RunPipelineOperator.GET_PIPELINE_RUN_PATH.format(run_id):
             nonlocal has_waited
 
             if not has_waited:
-                resp.content = f'{{"status": "{RunPipelineOperator.WAIT_STATUS[0]}"}}'
+                resp.content = '{{"status": "{}"}}'.format(
+                    RunPipelineOperator.WAIT_STATUS[0]
+                )
                 has_waited = True
             else:
-                resp.content = (
-                    f'{{"status": "{RunPipelineOperator.SUCCESS_STATUS[0]}"}}'
+                resp.content = '{{"status": "{}"}}'.format(
+                    RunPipelineOperator.SUCCESS_STATUS[0]
                 )
         elif endpoint == RunPipelineOperator.GET_ENVIRONMENT_PATH:
-            resp.content = f'[{{"public_id": "{environment_id}"}}]'
+            resp.content = '[{{"public_id": "{}"}}]'.format(environment_id)
         else:
             pytest.fail("Called with bad args")
         return resp

--- a/tests/test_run_pipeline_operator.py
+++ b/tests/test_run_pipeline_operator.py
@@ -45,14 +45,15 @@ def test_run_pipeline(airflow_connection):
 
     assert mock_resp.call_count >= 3
 
-    # get_env_call, run_pipeline_call, check_status_call, *others = mock_resp.mock_calls
     get_env_call = mock_resp.mock_calls[0]
-    run_pipeline_call = mock_resp.mock_calls[1]
-    check_status_call = mock_resp.mock_calls[2]
     assert get_env_call[1][0] == RunPipelineOperator.GET_ENVIRONMENT_PATH
+
+    run_pipeline_call = mock_resp.mock_calls[1]
     assert run_pipeline_call[1][0] == RunPipelineOperator.RUN_PIPELINE_PATH.format(
         pipeline_id
     )
+
+    check_status_call = mock_resp.mock_calls[2]
     assert check_status_call[1][0] == RunPipelineOperator.GET_PIPELINE_RUN_PATH.format(
         run_id
     )
@@ -100,14 +101,15 @@ def test_run_pipeline_waiting(airflow_connection):
 
     assert mock_resp.call_count >= 3
 
-    # get_env_call, run_pipeline_call, check_status_call, *others = mock_resp.mock_calls
     get_env_call = mock_resp.mock_calls[0]
-    run_pipeline_call = mock_resp.mock_calls[1]
-    check_status_call = mock_resp.mock_calls[2]
     assert get_env_call[1][0] == RunPipelineOperator.GET_ENVIRONMENT_PATH
+
+    run_pipeline_call = mock_resp.mock_calls[1]
     assert run_pipeline_call[1][0] == RunPipelineOperator.RUN_PIPELINE_PATH.format(
         pipeline_id
     )
+
+    check_status_call = mock_resp.mock_calls[2]
     assert check_status_call[1][0] == RunPipelineOperator.GET_PIPELINE_RUN_PATH.format(
         run_id
     )
@@ -149,20 +151,20 @@ def test_run_pipeline_failure(airflow_connection):
     assert ex.value.args[0] == "Run status is {}".format(fail_status)
     assert mock_resp.call_count >= 4
 
-    # get_env_call, run_pipeline_call, check_status_call, stop_run_call, *others = (
-    #     mock_resp.mock_calls
-    # )
     get_env_call = mock_resp.mock_calls[0]
-    run_pipeline_call = mock_resp.mock_calls[1]
-    check_status_call = mock_resp.mock_calls[2]
-    stop_run_call = mock_resp.mock_calls[3]
     assert get_env_call[1][0] == RunPipelineOperator.GET_ENVIRONMENT_PATH
+
+    run_pipeline_call = mock_resp.mock_calls[1]
     assert run_pipeline_call[1][0] == RunPipelineOperator.RUN_PIPELINE_PATH.format(
         pipeline_id
     )
+
+    check_status_call = mock_resp.mock_calls[2]
     assert check_status_call[1][0] == RunPipelineOperator.GET_PIPELINE_RUN_PATH.format(
         run_id
     )
+
+    stop_run_call = mock_resp.mock_calls[3]
     assert stop_run_call[1][0] == RunPipelineOperator.STOP_PIPELINE_RUN_PATH.format(
         run_id
     )


### PR DESCRIPTION
Changes:
- Use `str.format()` instead of `f-strings`
- Use Python 2 backport for `super()`
- Rewrite code that uses py3 specific syntax such as `nonlocal`, tuple unpack 

Fixes https://github.com/basisai/bedrock-airflow/issues/10