### PR TITLE
[BDRK-872] Update run pipeline route to use /training_pipeline instead of /pipeline

### DIFF
--- a/bedrock_plugin.py
+++ b/bedrock_plugin.py
@@ -44,7 +44,7 @@ class RunPipelineOperator(BaseOperator):
         stop the operator.
     """
 
-    RUN_PIPELINE_PATH = "/{}/pipeline/{{}}/run/".format(API_VERSION)
+    RUN_PIPELINE_PATH = "/{}/training_pipeline/{{}}/run/".format(API_VERSION)
     GET_PIPELINE_RUN_PATH = "/{}/run/{{}}".format(API_VERSION)
     STOP_PIPELINE_RUN_PATH = "/{}/training_run/{{}}/status".format(API_VERSION)
     WAIT_STATUS = ["Running", "Queued"]


### PR DESCRIPTION
[BDRK-872]

[BDRK-872]: https://basis-ai.atlassian.net/browse/BDRK-872